### PR TITLE
Dependency: Switch to prebuilt dependency for esy-freetype2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "refmterr": "^3.1.0",
     "reason-glfw": "^3.2.1001",
     "reason-gl-matrix":"^0.2.0",
-    "esy-cmake": "^0.3.2",
-    "esy-freetype2": "^2.9.1001",
+    "esy-freetype2-prebuilt": "^2.9.1001",
     "esy-harfbuzz": "^1.9.1"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "refmterr": "^3.1.0",
     "reason-glfw": "^3.2.1001",
     "reason-gl-matrix":"^0.2.0",
-    "esy-freetype2-prebuilt": "^2.9.1003",
-    "esy-harfbuzz-prebuilt": "^1.9.1000"
+    "esy-freetype2-prebuilt": "^2.9.1005",
+    "esy-harfbuzz": "^1.9.1"
   },
   "resolutions": {
     "@opam/cmdliner": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "reason-glfw": "^3.2.1001",
     "reason-gl-matrix":"^0.2.0",
     "esy-freetype2-prebuilt": "^2.9.1002",
-    "esy-harfbuzz": "^1.9.1"
+    "esy-harfbuzz-prebuilt": "^1.9.1"
   },
   "resolutions": {
     "@opam/cmdliner": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "reason-glfw": "^3.2.1001",
     "reason-gl-matrix":"^0.2.0",
     "esy-freetype2-prebuilt": "^2.9.1003",
-    "esy-harfbuzz": "^1.9.1"
+    "esy-harfbuzz-prebuilt": "^1.9.1000"
   },
   "resolutions": {
     "@opam/cmdliner": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "refmterr": "^3.1.0",
     "reason-glfw": "^3.2.1001",
     "reason-gl-matrix":"^0.2.0",
-    "esy-freetype2-prebuilt": "^2.9.1002",
-    "esy-harfbuzz-prebuilt": "^1.9.1"
+    "esy-freetype2-prebuilt": "^2.9.1003",
+    "esy-harfbuzz": "^1.9.1"
   },
   "resolutions": {
     "@opam/cmdliner": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "refmterr": "^3.1.0",
     "reason-glfw": "^3.2.1001",
     "reason-gl-matrix":"^0.2.0",
-    "esy-freetype2-prebuilt": "^2.9.1001",
+    "esy-freetype2-prebuilt": "^2.9.1002",
     "esy-harfbuzz": "^1.9.1"
   },
   "resolutions": {


### PR DESCRIPTION
Switching to prebuilt binaries, so we can skip out on the `esy-cmake` build step