### PR TITLE
Bugfix: Glyph positioning in JS render strategy

### DIFF
--- a/src/fontkit.js
+++ b/src/fontkit.js
@@ -76,21 +76,36 @@ function caml_fk_load_glyph(face /*: fk_face */, glyphId /*: number */) {
     // TODO: Can we reuse the same canvas element?
     var canvas = document.createElement("canvas");
     var scale = (1 / face.unitsPerEm) * face.size;
+      console.log("SCALE: " + scale);
     var advanceWidth = glyph.advanceWidth * scale;
     var bearingX = glyph._metrics.leftBearing * scale;
-    var bearingY = -glyph._metrics.topBearing * scale;
-    canvas.width = face.size;
-    canvas.height = face.size;
+    var bearingY = glyph._metrics.topBearing * scale;
+    var glyphWidth = Math.ceil((glyph.bbox.maxX - glyph.bbox.minX) * scale);
+    var glyphHeight = Math.ceil((glyph.bbox.maxY - glyph.bbox.minY) * scale);
+    canvas.width = glyphWidth;
+    canvas.height = glyphHeight;
     var ctx = canvas.getContext("2d");
-    ctx.translate(0, glyph.bbox.maxY * scale);
+      ctx.save();
+      // ctx.beginPath();
+      // ctx.lineWidth = 3;
+      // ctx.strokeStyle = "rgba(1.0, 0.0, 0.0, 0.5)";
+      // ctx.fillStyle = "rgba(1.0, 0, 0, 0.1)";
+      // ctx.fillRect(0, 0, face.size, face.size);
+      // ctx.stroke();
+      // ctx.closePath();
+      ctx.restore();
+    ctx.translate( -bearingX, glyph.bbox.maxY * scale);
     ctx.scale(1, -1);
     glyph.render(ctx, face.size);
+    // var height = (glyph.bbox.maxY - glyph.bbox.minY) * scale;
+    //   console.log("HEIGHT: " + height);
+    //   console.log("FACE SIZE: " + face.size);
     return createSuccessValue([
       /* <jsoo_empty> */ 0,
-      /* width */ face.size,
-      /* height */ face.size,
+      /* width */ glyphWidth,
+      /* height */ glyphHeight,
       /* bearingX */ bearingX,
-      /* bearingY */ bearingY,
+      /* bearingY */ face.size -bearingY,
       /* advance */ advanceWidth * 64,
       /* image */ canvas
     ]);

--- a/src/fontkit.js
+++ b/src/fontkit.js
@@ -76,7 +76,6 @@ function caml_fk_load_glyph(face /*: fk_face */, glyphId /*: number */) {
     // TODO: Can we reuse the same canvas element?
     var canvas = document.createElement("canvas");
     var scale = (1 / face.unitsPerEm) * face.size;
-      console.log("SCALE: " + scale);
     var advanceWidth = glyph.advanceWidth * scale;
     var bearingX = glyph._metrics.leftBearing * scale;
     var bearingY = glyph._metrics.topBearing * scale;
@@ -85,21 +84,9 @@ function caml_fk_load_glyph(face /*: fk_face */, glyphId /*: number */) {
     canvas.width = glyphWidth;
     canvas.height = glyphHeight;
     var ctx = canvas.getContext("2d");
-      ctx.save();
-      // ctx.beginPath();
-      // ctx.lineWidth = 3;
-      // ctx.strokeStyle = "rgba(1.0, 0.0, 0.0, 0.5)";
-      // ctx.fillStyle = "rgba(1.0, 0, 0, 0.1)";
-      // ctx.fillRect(0, 0, face.size, face.size);
-      // ctx.stroke();
-      // ctx.closePath();
-      ctx.restore();
     ctx.translate( -bearingX, glyph.bbox.maxY * scale);
     ctx.scale(1, -1);
     glyph.render(ctx, face.size);
-    // var height = (glyph.bbox.maxY - glyph.bbox.minY) * scale;
-    //   console.log("HEIGHT: " + height);
-    //   console.log("FACE SIZE: " + face.size);
     return createSuccessValue([
       /* <jsoo_empty> */ 0,
       /* width */ glyphWidth,


### PR DESCRIPTION
__Issue:__ Was testing out the calculator branch in revery-ui/revery#174 in the JS strategy - and things actually work _surprisingly_ well. It's so cool to see the web strategy work, thanks to @jchavarri 's heroic effort to setup a JS-side text rendering strategy!

One issue we saw was a positioning issue in the JS strategy:
![calculator-web](https://user-images.githubusercontent.com/13532591/50668595-d1ae6100-0f74-11e9-8aaa-3d7b2b495f12.gif)

It seemed almost as if the text was rendered a line lower.

This change adjust the alignment / rendering of the glyphs to be in parity with the native strategy:
- Constrain the canvas context to the glyph size (so we use `glyphWidth`/`glyphHeight` for the canvas dimensions, instead of `face.size`).
- Adjust the `bearingY` to be `face.size - bearingY` to bring up to a consistent baseline with the native strategy.

With those small tweaks, the text is now aligned consistently in the web strategy with the native strategy:
![image](https://user-images.githubusercontent.com/13532591/50668646-26ea7280-0f75-11e9-8027-bbd09b0f7284.png)

Really neat to see an interactive app work both in WebGL and native!

