### PR TITLE
Convert strings to UTF-16 in JS

### DIFF
--- a/src/fontkit.js
+++ b/src/fontkit.js
@@ -84,7 +84,7 @@ function caml_fk_load_glyph(face /*: fk_face */, glyphId /*: number */) {
     canvas.width = glyphWidth;
     canvas.height = glyphHeight;
     var ctx = canvas.getContext("2d");
-    ctx.translate( -bearingX, glyph.bbox.maxY * scale);
+    ctx.translate(-bearingX, glyph.bbox.maxY * scale);
     ctx.scale(1, -1);
     glyph.render(ctx, face.size);
     return createSuccessValue([
@@ -92,7 +92,7 @@ function caml_fk_load_glyph(face /*: fk_face */, glyphId /*: number */) {
       /* width */ glyphWidth,
       /* height */ glyphHeight,
       /* bearingX */ bearingX,
-      /* bearingY */ face.size -bearingY,
+      /* bearingY */ face.size - bearingY,
       /* advance */ advanceWidth * 64,
       /* image */ canvas
     ]);
@@ -104,7 +104,7 @@ function caml_fk_load_glyph(face /*: fk_face */, glyphId /*: number */) {
 function caml_fk_shape(face /*: fk_face */, text /*: string */) {
   // TODO: Is there any available function to get the JS string from an OCaml
   // string? Would be better than relying on internal representation
-  var str = text.c;
+  var str = joo_global_object.jsoo_runtime.caml_utf16_of_utf8(text.c);
   var isDummy = isDummyFont(face);
   var ret;
   if (isDummy) {


### PR DESCRIPTION
Fixes #14.

I stumbled upon a thread in OCaml discord where they mentioned `Js.string` converted to JS utf-16 from (pseudo)utf-8 from OCaml.

We can't use the "OCaml-side" approach of jsoo `Js.string`, because we want the Reason side code to be platform agnostic. But looking at the runtime functions, I found this [`caml_utf16_of_utf8`](https://github.com/ocsigen/js_of_ocaml/blob/78dc4facee0eb15b05dfcea145126e426ae7133a/runtime/mlString.js#L119) which seems to do the trick.

One open question is: would be if it'd be better to use [`caml_to_js_string`](https://github.com/ocsigen/js_of_ocaml/blob/78dc4facee0eb15b05dfcea145126e426ae7133a/runtime/mlString.js#L178-L193)? 🤔 I _think_ we always want to convert as we don't plan to pass bytes.

And the companion image of course! 🚀 

<img width="817" alt="image" src="https://user-images.githubusercontent.com/220424/50867562-f27b1a00-13ab-11e9-8dd5-3bc3595f0fdc.png">