### PR TITLE
Fix bug when using release profile - 'caml_to_js_string' is not defiend

### DIFF
--- a/src/fontkit.js
+++ b/src/fontkit.js
@@ -100,9 +100,9 @@ function caml_fk_load_glyph(face /*: fk_face */, glyphId /*: number */) {
 }
 
 // Provides: caml_fk_shape
-// Requires: isDummyFont
+// Requires: isDummyFont, caml_to_js_string
 function caml_fk_shape(face /*: fk_face */, text /*: string */) {
-  var str = joo_global_object.jsoo_runtime.caml_to_js_string(text);
+  var str = caml_to_js_string(text);
   var isDummy = isDummyFont(face);
   var ret;
   if (isDummy) {


### PR DESCRIPTION
In revery, we're working on publishing a WebGL/JS build to publish on our website. The 'non-optimized' build clocks in at multiple megabytes, but with a release build, its ~700KB.

However, there's a bug on startup - there's a reference to `caml_js_to_string` that somehow gets left in and doesn't get fixed. This addresses it so JSOO knows to match up this token for release builds.