### PR TITLE
Use hb_blob_create_from_file for mmap file reading

### DIFF
--- a/src/fontkit.cpp
+++ b/src/fontkit.cpp
@@ -65,17 +65,9 @@ extern "C" {
     hb_font_t*
     get_font_ot(const char *filename, int size)
     {
-      FILE* file = fopen(filename, "rb");
-      fseek(file, 0, SEEK_END);
-      unsigned int length = ftell(file);
-      fseek(file, 0, SEEK_SET);
-
-      char* data = (char *)malloc(length);
-      fread(data, length, 1, file);
-      fclose(file);
-
-      hb_blob_t* blob = hb_blob_create(data, length, HB_MEMORY_MODE_WRITABLE, (void*)data, NULL);
+      hb_blob_t* blob = hb_blob_create_from_file(filename);
       hb_face_t* face = hb_face_create(blob, 0);
+      hb_blob_destroy(blob);
       hb_font_t* font = hb_font_create(face);
 
       hb_ot_font_set_funcs(font);


### PR DESCRIPTION
Not tested locally however.

Merge it with caution, if you like to. The advantage is to not have all the file at once by using mmap where possible instead.