### PR TITLE
Add 'fk_get_metrics' API

### DIFF
--- a/bin_native/test_fontkit.re
+++ b/bin_native/test_fontkit.re
@@ -39,6 +39,11 @@ let run = () => {
 
   let%lwt font = Fontkit.load("Roboto-Regular.ttf", 24);
 
+  let metrics = Fontkit.fk_get_metrics(font);
+  print_endline ("-- lineGap: " ++ string_of_int(metrics.lineGap));
+  print_endline ("-- ascent: " ++ string_of_int(metrics.ascent));
+  print_endline ("-- descent: " ++ string_of_int(metrics.descent));
+
   let vsSource = {|
         #ifndef GL_ES
         #define lowp

--- a/bin_native/test_fontkit.re
+++ b/bin_native/test_fontkit.re
@@ -43,6 +43,8 @@ let run = () => {
   print_endline ("-- lineGap: " ++ string_of_int(metrics.lineGap));
   print_endline ("-- ascent: " ++ string_of_int(metrics.ascent));
   print_endline ("-- descent: " ++ string_of_int(metrics.descent));
+  print_endline ("-- underlinePosition: " ++ string_of_int(metrics.underlinePosition));
+  print_endline ("-- underlineThickness: " ++ string_of_int(metrics.underlineThickness));
 
   let vsSource = {|
         #ifndef GL_ES

--- a/bin_native/test_fontkit.re
+++ b/bin_native/test_fontkit.re
@@ -40,7 +40,7 @@ let run = () => {
   let%lwt font = Fontkit.load("Roboto-Regular.ttf", 24);
 
   let metrics = Fontkit.fk_get_metrics(font);
-  print_endline ("-- lineGap: " ++ string_of_int(metrics.lineGap));
+  print_endline ("-- height: " ++ string_of_int(metrics.height));
   print_endline ("-- ascent: " ++ string_of_int(metrics.ascent));
   print_endline ("-- descent: " ++ string_of_int(metrics.descent));
   print_endline ("-- underlinePosition: " ++ string_of_int(metrics.underlinePosition));

--- a/bin_native/test_fontkit.re
+++ b/bin_native/test_fontkit.re
@@ -45,6 +45,7 @@ let run = () => {
   print_endline ("-- descent: " ++ string_of_int(metrics.descent));
   print_endline ("-- underlinePosition: " ++ string_of_int(metrics.underlinePosition));
   print_endline ("-- underlineThickness: " ++ string_of_int(metrics.underlineThickness));
+  print_endline ("-- unitsPerEm: " ++ string_of_int(metrics.unitsPerEm));
 
   let vsSource = {|
         #ifndef GL_ES

--- a/src/Fontkit.re
+++ b/src/Fontkit.re
@@ -41,6 +41,18 @@ type fk_metrics = {
      * Vertical distance from the horizontal baseline to the lowest 'character' coordinate
      */
     descent: int,
+
+    /*
+     * Vertical position, relative to the baseline, of the undelrine bar's center.
+     * Negative if below baseline
+     */
+    underlinePosition: int,
+
+    /*
+     * When displaying or rendering underlined text, this value corresponds to the
+     * vertical thickness of the underline.
+     */
+    underlineThickness: int,
 };
 
 type fk_shape = {

--- a/src/Fontkit.re
+++ b/src/Fontkit.re
@@ -3,8 +3,6 @@ open Reglfw;
 exception FontKitLoadFaceException(string);
 exception FontKitRenderGlyphException(string);
 
-social: - 14 - why is it working?
-
 type fk_return('a) =
 | Success('a)
 | Error(string);
@@ -30,7 +28,7 @@ type fk_metrics = {
      *
      * Essentially, a default line spacing for the font.
      */
-    lineGap: int,   
+    height: int,   
 
     /*
      * Vertical distance from the horizontal baseline to the highest 'character' coordinate
@@ -53,6 +51,11 @@ type fk_metrics = {
      * vertical thickness of the underline.
      */
     underlineThickness: int,
+
+    /*
+     * unitsPerEm
+     */
+    unitsPerEm: int,
 };
 
 type fk_shape = {

--- a/src/Fontkit.re
+++ b/src/Fontkit.re
@@ -56,6 +56,11 @@ type fk_metrics = {
      * unitsPerEm
      */
     unitsPerEm: int,
+
+    /*
+     * The integer size passed in when loading the font
+     */
+    size: int,
 };
 
 type fk_shape = {
@@ -67,6 +72,14 @@ external fk_new_face: (string, int, successCallback, failureCallback) => unit = 
 external fk_load_glyph: (fk_face, int) => fk_return(fk_glyph) = "caml_fk_load_glyph";
 external fk_shape: (fk_face, string) => array(fk_shape) = "caml_fk_shape";
 external fk_dummy_font: int => fk_face = "caml_fk_dummy_font";
+
+
+
+
+
+
+
+
 external fk_get_metrics: fk_face => fk_metrics = "caml_fk_get_metrics";
 
 let dummyFont = fk_dummy_font;

--- a/src/Fontkit.re
+++ b/src/Fontkit.re
@@ -3,6 +3,8 @@ open Reglfw;
 exception FontKitLoadFaceException(string);
 exception FontKitRenderGlyphException(string);
 
+social: - 14 - why is it working?
+
 type fk_return('a) =
 | Success('a)
 | Error(string);
@@ -20,6 +22,27 @@ advance: int,
 image: Image.t
 };
 
+type fk_metrics = {
+    /*
+     * This represents the 'height' FT_Global_Metric -
+     * From FreeType2 documentation:
+     * https://www.freetype.org/freetype2/docs/tutorial/step2.html
+     *
+     * Essentially, a default line spacing for the font.
+     */
+    lineGap: int,   
+
+    /*
+     * Vertical distance from the horizontal baseline to the highest 'character' coordinate
+     */
+    ascent: int,
+
+    /*
+     * Vertical distance from the horizontal baseline to the lowest 'character' coordinate
+     */
+    descent: int,
+};
+
 type fk_shape = {
     glyphId: int,
     cluster: int
@@ -29,6 +52,7 @@ external fk_new_face: (string, int, successCallback, failureCallback) => unit = 
 external fk_load_glyph: (fk_face, int) => fk_return(fk_glyph) = "caml_fk_load_glyph";
 external fk_shape: (fk_face, string) => array(fk_shape) = "caml_fk_shape";
 external fk_dummy_font: int => fk_face = "caml_fk_dummy_font";
+external fk_get_metrics: fk_face => fk_metrics = "caml_fk_get_metrics";
 
 let dummyFont = fk_dummy_font;
 

--- a/src/Fontkit.re
+++ b/src/Fontkit.re
@@ -4,81 +4,70 @@ exception FontKitLoadFaceException(string);
 exception FontKitRenderGlyphException(string);
 
 type fk_return('a) =
-| Success('a)
-| Error(string);
+  | Success('a)
+  | Error(string);
 
 type fk_face;
 type successCallback = fk_face => unit;
 type failureCallback = string => unit;
 
 type fk_glyph = {
-width: int,
-height: int,
-bearingX: int,
-bearingY: int,
-advance: int,
-image: Image.t
+  width: int,
+  height: int,
+  bearingX: int,
+  bearingY: int,
+  advance: int,
+  image: Image.t,
 };
 
 type fk_metrics = {
-    /*
-     * This represents the 'height' FT_Global_Metric -
-     * From FreeType2 documentation:
-     * https://www.freetype.org/freetype2/docs/tutorial/step2.html
-     *
-     * Essentially, a default line spacing for the font.
-     */
-    height: int,   
-
-    /*
-     * Vertical distance from the horizontal baseline to the highest 'character' coordinate
-     */
-    ascent: int,
-
-    /*
-     * Vertical distance from the horizontal baseline to the lowest 'character' coordinate
-     */
-    descent: int,
-
-    /*
-     * Vertical position, relative to the baseline, of the undelrine bar's center.
-     * Negative if below baseline
-     */
-    underlinePosition: int,
-
-    /*
-     * When displaying or rendering underlined text, this value corresponds to the
-     * vertical thickness of the underline.
-     */
-    underlineThickness: int,
-
-    /*
-     * unitsPerEm
-     */
-    unitsPerEm: int,
-
-    /*
-     * The integer size passed in when loading the font
-     */
-    size: int,
+  /*
+   * This represents the 'height' FT_Global_Metric -
+   * From FreeType2 documentation:
+   * https://www.freetype.org/freetype2/docs/tutorial/step2.html
+   *
+   * Essentially, a default line spacing for the font.
+   */
+  height: int,
+  /*
+   * Vertical distance from the horizontal baseline to the highest 'character' coordinate
+   */
+  ascent: int,
+  /*
+   * Vertical distance from the horizontal baseline to the lowest 'character' coordinate
+   */
+  descent: int,
+  /*
+   * Vertical position, relative to the baseline, of the undelrine bar's center.
+   * Negative if below baseline
+   */
+  underlinePosition: int,
+  /*
+   * When displaying or rendering underlined text, this value corresponds to the
+   * vertical thickness of the underline.
+   */
+  underlineThickness: int,
+  /*
+   * unitsPerEm
+   */
+  unitsPerEm: int,
+  /*
+   * The integer size passed in when loading the font
+   */
+  size: int,
 };
 
 type fk_shape = {
-    glyphId: int,
-    cluster: int
+  glyphId: int,
+  cluster: int,
 };
 
-external fk_new_face: (string, int, successCallback, failureCallback) => unit = "caml_fk_new_face";
-external fk_load_glyph: (fk_face, int) => fk_return(fk_glyph) = "caml_fk_load_glyph";
+external fk_new_face: (string, int, successCallback, failureCallback) => unit =
+  "caml_fk_new_face";
+external fk_load_glyph: (fk_face, int) => fk_return(fk_glyph) =
+  "caml_fk_load_glyph";
 external fk_shape: (fk_face, string) => array(fk_shape) = "caml_fk_shape";
 external fk_dummy_font: int => fk_face = "caml_fk_dummy_font";
-
-
-
-
-
-
-
 
 external fk_get_metrics: fk_face => fk_metrics = "caml_fk_get_metrics";
 
@@ -96,9 +85,9 @@ let load = (fontFile, size) => {
 };
 
 let renderGlyph = (face, glyphId) => {
-    let glyph = fk_load_glyph(face, glyphId);
-    switch (glyph) {
-    | Success(g) => g
-    | Error(msg) => raise(FontKitRenderGlyphException(msg))
-}
+  let glyph = fk_load_glyph(face, glyphId);
+  switch (glyph) {
+  | Success(g) => g
+  | Error(msg) => raise(FontKitRenderGlyphException(msg))
+  };
 };

--- a/src/fontkit.cpp
+++ b/src/fontkit.cpp
@@ -26,6 +26,7 @@ extern "C" {
     struct FontKitFace {
         FT_Face* pFreeTypeFace;
         hb_font_t* pHarfbuzzFace;
+        int iSize;
     };
 
     struct FontCharacterInfo {
@@ -115,6 +116,9 @@ extern "C" {
             FontKitFace* pFontKitFace = (FontKitFace *)malloc(sizeof(FontKitFace));
             pFontKitFace->pFreeTypeFace = face;
             pFontKitFace->pHarfbuzzFace = hb_font;
+            pFontKitFace->iSize = iSize;
+            printf("Setting pFontKitFace->iSize: %d\n", iSize);
+            printf("Actual vale pFontKitFace->iSize: %d\n", pFontKitFace->iSize);
 
             caml_callback(vSuccess, (value)pFontKitFace);
         }
@@ -225,34 +229,60 @@ extern "C" {
         CAMLparam1(vFace);    
         CAMLlocal1(ret);
 
-        FontKitFace *pFontKitFace = (FontKitFace *)vFace;
-        FT_Face* pFreeTypeFace = pFontKitFace->pFreeTypeFace;
+        ret = caml_alloc(7, 0);
 
-        int lineGap = -1;
-        int ascent = -1;
-        int descent = -1;
-        int underlinePosition = 0;
-        int underlineThickness = 1;
-        int unitsPerEm = 1;
-        ret = caml_alloc(6, 0);
+        if (is_dummy((char *)vFace)) {
+            Store_field(ret, 0, Val_int(1));
+            Store_field(ret, 1, Val_int(1));
+            Store_field(ret, 2, Val_int(1));
+            Store_field(ret, 3, Val_int(1));
+            Store_field(ret, 4, Val_int(1));
+            Store_field(ret, 5, Val_int(1));
+            Store_field(ret, 6, Val_int(1));
+        } else {
+            fprintf(stderr, "1!\n");
 
-        FT_Face face = *pFreeTypeFace;
+            FontKitFace *pFontKitFace = (FontKitFace *)vFace;
+            FT_Face* pFreeTypeFace = pFontKitFace->pFreeTypeFace;
 
-        if (FT_IS_SCALABLE(face)) {
-            lineGap = face->height;
-            ascent = face->ascender;
-            descent = face->descender;
-            underlinePosition = face->underline_position;
-            underlineThickness = face->underline_thickness;
-            unitsPerEm = face->units_per_EM;
+            printf("2\n");
+            int lineGap = -1;
+            int ascent = -1;
+            int descent = -1;
+            int underlinePosition = 0;
+            int underlineThickness = 1;
+            int unitsPerEm = 1;
+            int size = pFontKitFace->iSize;
+            printf("3\n");
+
+
+            printf(" pFontKitFace: %p\n", pFontKitFace);
+            printf(" pFreeTypeFace: %p\n", pFreeTypeFace);
+            printf(" pFreeTypeFace: %p\n", pFreeTypeFace);
+            printf(" size: %d\n", pFontKitFace->iSize);
+            FT_Face face = *pFreeTypeFace;
+            printf("4\n");
+
+            if (FT_IS_SCALABLE(face)) {
+                lineGap = face->height;
+                ascent = face->ascender;
+                descent = face->descender;
+                underlinePosition = face->underline_position;
+                underlineThickness = face->underline_thickness;
+                unitsPerEm = face->units_per_EM;
+            }
+            printf("5\n");
+
+            Store_field(ret, 0, Val_int(lineGap));
+            Store_field(ret, 1, Val_int(ascent));
+            Store_field(ret, 2, Val_int(descent));
+            Store_field(ret, 3, Val_int(underlinePosition));
+            Store_field(ret, 4, Val_int(underlineThickness));
+            Store_field(ret, 5, Val_int(unitsPerEm));
+            Store_field(ret, 6, Val_int(size));
+            printf("6\n");
+
         }
-
-        Store_field(ret, 0, Int_val(lineGap));
-        Store_field(ret, 1, Int_val(ascent));
-        Store_field(ret, 2, Int_val(descent));
-        Store_field(ret, 3, Int_val(underlinePosition));
-        Store_field(ret, 4, Int_val(underlineThickness));
-        Store_field(ret, 5, Int_val(unitsPerEm));
 
         CAMLreturn(ret);
     }

--- a/src/fontkit.cpp
+++ b/src/fontkit.cpp
@@ -233,14 +233,18 @@ extern "C" {
         int descent = -1;
         int underlinePosition = 0;
         int underlineThickness = 1;
-        ret = caml_alloc(5, 0);
+        int unitsPerEm = 1;
+        ret = caml_alloc(6, 0);
 
-        if (FT_IS_SCALABLE(pFreeTypeFace)) {
-            lineGap = pFreeTypeFace->height;
-            ascent = pFreeTypeFace->ascender;
-            descent = pFreeTypeFace->descender;
-            underlinePosition = pFreeTypeFace->underlinePosition;
-            underlineThickness = pFreeTypeFace->underlineThickness;
+        FT_Face face = *pFreeTypeFace;
+
+        if (FT_IS_SCALABLE(face)) {
+            lineGap = face->height;
+            ascent = face->ascender;
+            descent = face->descender;
+            underlinePosition = face->underline_position;
+            underlineThickness = face->underline_thickness;
+            unitsPerEm = face->units_per_EM;
         }
 
         Store_field(ret, 0, Int_val(lineGap));
@@ -248,6 +252,7 @@ extern "C" {
         Store_field(ret, 2, Int_val(descent));
         Store_field(ret, 3, Int_val(underlinePosition));
         Store_field(ret, 4, Int_val(underlineThickness));
+        Store_field(ret, 5, Int_val(unitsPerEm));
 
         CAMLreturn(ret);
     }

--- a/src/fontkit.cpp
+++ b/src/fontkit.cpp
@@ -231,17 +231,24 @@ extern "C" {
         int lineGap = -1;
         int ascent = -1;
         int descent = -1;
-        ret = caml_alloc(3, 0);
+        int underlinePosition = 0;
+        int underlineThickness = 1;
+        ret = caml_alloc(5, 0);
 
         if (FT_IS_SCALABLE(pFreeTypeFace)) {
             lineGap = pFreeTypeFace->height;
             ascent = pFreeTypeFace->ascender;
             descent = pFreeTypeFace->descender;
+            underlinePosition = pFreeTypeFace->underlinePosition;
+            underlineThickness = pFreeTypeFace->underlineThickness;
         }
 
         Store_field(ret, 0, Int_val(lineGap));
         Store_field(ret, 1, Int_val(ascent));
         Store_field(ret, 2, Int_val(descent));
+        Store_field(ret, 3, Int_val(underlinePosition));
+        Store_field(ret, 4, Int_val(underlineThickness));
+
         CAMLreturn(ret);
     }
 

--- a/src/fontkit.cpp
+++ b/src/fontkit.cpp
@@ -117,9 +117,6 @@ extern "C" {
             pFontKitFace->pFreeTypeFace = face;
             pFontKitFace->pHarfbuzzFace = hb_font;
             pFontKitFace->iSize = iSize;
-            printf("Setting pFontKitFace->iSize: %d\n", iSize);
-            printf("Actual vale pFontKitFace->iSize: %d\n", pFontKitFace->iSize);
-
             caml_callback(vSuccess, (value)pFontKitFace);
         }
         CAMLreturn(Val_unit);
@@ -226,7 +223,7 @@ extern "C" {
 
     CAMLprim value
     caml_fk_get_metrics(value vFace) {
-        CAMLparam1(vFace);    
+        CAMLparam1(vFace);
         CAMLlocal1(ret);
 
         ret = caml_alloc(7, 0);
@@ -240,12 +237,9 @@ extern "C" {
             Store_field(ret, 5, Val_int(1));
             Store_field(ret, 6, Val_int(1));
         } else {
-            fprintf(stderr, "1!\n");
-
             FontKitFace *pFontKitFace = (FontKitFace *)vFace;
             FT_Face* pFreeTypeFace = pFontKitFace->pFreeTypeFace;
 
-            printf("2\n");
             int lineGap = -1;
             int ascent = -1;
             int descent = -1;
@@ -253,15 +247,8 @@ extern "C" {
             int underlineThickness = 1;
             int unitsPerEm = 1;
             int size = pFontKitFace->iSize;
-            printf("3\n");
 
-
-            printf(" pFontKitFace: %p\n", pFontKitFace);
-            printf(" pFreeTypeFace: %p\n", pFreeTypeFace);
-            printf(" pFreeTypeFace: %p\n", pFreeTypeFace);
-            printf(" size: %d\n", pFontKitFace->iSize);
             FT_Face face = *pFreeTypeFace;
-            printf("4\n");
 
             if (FT_IS_SCALABLE(face)) {
                 lineGap = face->height;
@@ -271,7 +258,6 @@ extern "C" {
                 underlineThickness = face->underline_thickness;
                 unitsPerEm = face->units_per_EM;
             }
-            printf("5\n");
 
             Store_field(ret, 0, Val_int(lineGap));
             Store_field(ret, 1, Val_int(ascent));
@@ -280,8 +266,6 @@ extern "C" {
             Store_field(ret, 4, Val_int(underlineThickness));
             Store_field(ret, 5, Val_int(unitsPerEm));
             Store_field(ret, 6, Val_int(size));
-            printf("6\n");
-
         }
 
         CAMLreturn(ret);

--- a/src/fontkit.cpp
+++ b/src/fontkit.cpp
@@ -221,6 +221,31 @@ extern "C" {
     }
 
     CAMLprim value
+    caml_fk_get_metrics(value vFace) {
+        CAMLparam1(vFace);    
+        CAMLlocal1(ret);
+
+        FontKitFace *pFontKitFace = (FontKitFace *)vFace;
+        FT_Face* pFreeTypeFace = pFontKitFace->pFreeTypeFace;
+
+        int lineGap = -1;
+        int ascent = -1;
+        int descent = -1;
+        ret = caml_alloc(3, 0);
+
+        if (FT_IS_SCALABLE(pFreeTypeFace)) {
+            lineGap = pFreeTypeFace->height;
+            ascent = pFreeTypeFace->ascender;
+            descent = pFreeTypeFace->descender;
+        }
+
+        Store_field(ret, 0, Int_val(lineGap));
+        Store_field(ret, 1, Int_val(ascent));
+        Store_field(ret, 2, Int_val(descent));
+        CAMLreturn(ret);
+    }
+
+    CAMLprim value
     caml_fk_dummy_font() {
         CAMLparam0();
         CAMLlocal1(ret);

--- a/src/fontkit.js
+++ b/src/fontkit.js
@@ -52,6 +52,16 @@ function caml_fk_new_face(
   return undefined;
 }
 
+// Provides: caml_fk_get_metrics
+function caml_fk_get_metrics(
+  face /*fk_face */
+) {
+
+    var height = Math.abs(face.ascent) + Math.abs(face.descent) + face.lineGap;
+
+    return [0, height, face.ascent, face.descent, face.underlinePosition, face.underlineThickness, face.unitsPerEm];
+}
+
 // Provides: caml_fk_load_glyph
 // Requires: isDummyFont, createSuccessValue
 function caml_fk_load_glyph(face /*: fk_face */, glyphId /*: number */) {

--- a/src/fontkit.js
+++ b/src/fontkit.js
@@ -53,13 +53,19 @@ function caml_fk_new_face(
 }
 
 // Provides: caml_fk_get_metrics
+// Requires: isDummyFont
 function caml_fk_get_metrics(
   face /*fk_face */
 ) {
 
-    var height = Math.abs(face.ascent) + Math.abs(face.descent) + face.lineGap;
+    var isDummy = isDummyFont(face);
+    if (isDummy) {
+      return [0, face[1], 0, 0, 0, 0, 1, face[1]];
+    } else {
+      var height = Math.abs(face.ascent) + Math.abs(face.descent) + face.lineGap;
 
-    return [0, height, face.ascent, face.descent, face.underlinePosition, face.underlineThickness, face.unitsPerEm];
+      return [0, height, face.ascent, face.descent, face.underlinePosition, face.underlineThickness, face.unitsPerEm, face.size];
+    }
 }
 
 // Provides: caml_fk_load_glyph


### PR DESCRIPTION
Our current `measure` logic in Revery is busted because we are only evaluating the glyph heights in our measurement: https://github.com/revery-ui/revery/blob/47e7b193129a627824fc3ef58158b21497580c21/src/UI/FontRenderer.re#L60

This means that glyphs that are small (ie, `-`), will initially report a very small height - this causes strange behavior when rendering text.

The fix is to pick up some of the global metrics from the font face, and use that to calculate the height instead.

This API is based on the metrics section of fontkitjs: https://github.com/revery-ui/revery/blob/47e7b193129a627824fc3ef58158b21497580c21/src/UI/FontRenderer.re#L60 as well as the global metrics defined in the freetype2 doc: https://www.freetype.org/freetype2/docs/tutorial/step2.html