### PR TITLE
Build: Add /opt/local/lib to link path

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -29,6 +29,7 @@ let extraFlags =
     | _ -> []
     @ ccopt ("-L/usr/lib")
     @ ccopt ("-L/usr/local/lib")
+    @ ccopt ("-L/opt/local/lib")
     @ cclib ("-lbz2")
     @ cclib ("-lpng")
     @ cclib ("-lz")


### PR DESCRIPTION
This adds `/opt/local/lib` - previously, we assumed `/usr/lib` and `/usr/local/lib`.  I'm not sure, though, if this is the best way - is there a better convention for finding the link folders we should expect to look on Mac? 

I'll bring this in for now, though - it shouldn't cause a problem per-se, just won't be maintainable to add random folders for link paths.

Perhaps the `pkg-config` approach would be better? 🤔 