### PR TITLE
Bugfix: OOM exception in Onivim 2

### DIFF
--- a/src/fontkit.cpp
+++ b/src/fontkit.cpp
@@ -134,8 +134,10 @@ extern "C" {
                 ret = Val_error("[ERROR]: Unable to render character at FT_Load_Char\n");
             } else {
                 FT_Bitmap bitmap = face->glyph->bitmap;
-                /* int bitmapDataLength = bitmap.rows * abs(bitmap.pitch); */
-                bitmapBigarray = caml_ba_alloc_dims(CAML_BA_UINT8 | CAML_BA_C_LAYOUT, 2, bitmap.buffer, bitmap.rows, abs(bitmap.pitch));
+                int bitmapDataLength = bitmap.rows * abs(bitmap.pitch);
+                char* c = (char *)malloc(sizeof(char) * bitmapDataLength);
+                bitmapBigarray = caml_ba_alloc_dims(CAML_BA_UINT8 | CAML_BA_C_LAYOUT, 2, (void *)c, bitmap.rows, abs(bitmap.pitch));
+                memcpy(Caml_ba_data_val(bitmapBigarray), (const char *)bitmap.buffer, bitmapDataLength);
 
                 record = caml_alloc(6, 0);
                 Store_field(record, 0, Val_int(bitmap.width));

--- a/src/fontkit.cpp
+++ b/src/fontkit.cpp
@@ -134,9 +134,8 @@ extern "C" {
                 ret = Val_error("[ERROR]: Unable to render character at FT_Load_Char\n");
             } else {
                 FT_Bitmap bitmap = face->glyph->bitmap;
-                int bitmapDataLength = bitmap.rows * abs(bitmap.pitch);
-                bitmapBigarray = caml_ba_alloc_dims(CAML_BA_UINT8 | CAML_BA_C_LAYOUT, 2, NULL, bitmap.rows, abs(bitmap.pitch));
-                memcpy(Caml_ba_data_val(bitmapBigarray), (const char *)bitmap.buffer, bitmapDataLength);
+                /* int bitmapDataLength = bitmap.rows * abs(bitmap.pitch); */
+                bitmapBigarray = caml_ba_alloc_dims(CAML_BA_UINT8 | CAML_BA_C_LAYOUT, 2, bitmap.buffer, bitmap.rows, abs(bitmap.pitch));
 
                 record = caml_alloc(6, 0);
                 Store_field(record, 0, Val_int(bitmap.width));


### PR DESCRIPTION
__Issue:__ After upgrading dependencies, received this error in Onivim 2:

```
Fatal error: exception Out of memory
Raised by primitive operation at file "src/Fontkit.re", line 89, characters 14-42
Called from file "src/Core/Revery_Core.re", line 43, characters 16-22
Called from file "src/Draw/Text.re", line 121, characters 18-56
Called from file "src/Draw/Text.re", line 170, characters 20-41
Called from file "array.ml", line 90, characters 31-48
Called from file "src/UI/TextNode.re", line 39, characters 8-295
Called from file "list.ml", line 110, characters 12-17
Called from file "list.ml", line 106, characters 12-15
Called from file "src/UI/Overflow.re", line 92, characters 2-5
Called from file "list.ml", line 106, characters 12-15
Called from file "src/UI/Overflow.re", line 92, characters 2-5
Called from file "list.ml", line 106, characters 12-15
Called from file "src/UI/Overflow.re", line 92, characters 2-5
Called from file "list.ml", line 106, characters 12-15
Called from file "src/UI/Overflow.re", line 92, characters 2-5
Called from file "list.ml", line 106, characters 12-15
Called from file "src/UI/Overflow.re", line 92, characters 2-5
Called from file "list.ml", line 106, characters 12-15
Called from file "src/UI/Overflow.re", line 92, characters 2-5
Called from file "list.ml", line 106, characters 12-15
Called from file "src/UI/Overflow.re", line 92, characters 2-5
Called from file "src/UI/Render.re", line 93, characters 4-17
Called from file "src/Core/Window.re", line 166, characters 2-12
Called from file "list.ml", line 106, characters 12-15
Called from file "src/Core/App.re", line 97, characters 10-67
Called from file "src/Core/App.re", line 96, characters 8-173
Called from file "src/glfw.re", line 192, characters 19-31
Called from file "src/editor/bin/Oni2.re", line 374, characters 0-53
```

__Defect:__ There is a bug with the memory allocation of bigarrays that is being hit: https://github.com/ocaml/ocaml/issues/4108 This seems to have been a pre-existing bug, but happened to be exercised when we upgraded to `reason-gl-matrix@0.9.9304`, which changed the memory allocation profile.

__Fix:__ We can workaround the bug by explicitly passing in the data instead of `memcpy`'ing it (the bug gets hit when we pass in `NULL` for the initial bigarray data). This is cheaper anyway.