### PR TITLE
Bugfix: Fix syntax error when fontkit-lib.compiled.js gets minified

### DIFF
--- a/src/fontkit-lib.compiled.js
+++ b/src/fontkit-lib.compiled.js
@@ -5062,7 +5062,7 @@ var FREEZE = !require('./_fails')(function () {
 });
 var setMeta = function (it) {
   setDesc(it, META, { value: {
-    i: 'O' + ++id, // object ID
+    i: 'O' + (++id).toString(), // object ID
     w: {}          // weak collections IDs
   } });
 };


### PR DESCRIPTION
There's a piece of syntax here:
```
i: 'O' + ++id, // object ID
```

That when run through JSOO in 'release' mode, gets changed to:
```
i: 'O' +++id, // object ID
```

`+++` isn't valid JS, so we get a syntax error.
