### PR TITLE
Dependency: Remove GLFW from primary package

### DIFF
--- a/bin_native/dune
+++ b/bin_native/dune
@@ -1,5 +1,6 @@
 (executable
     (name test_fontkit)
+    (package fontkit-example)
     (preprocess (pps lwt_ppx))
     (public_name test_fontkit)
     (libraries
@@ -11,5 +12,6 @@
             ))
 
 (install
+    (package fontkit-example)
     (section bin)
     (files Roboto-Regular.ttf image4.jpg))

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0500b0ed3b6491c5e017021de47d5369",
+  "checksum": "e7ab0bffcb905641319a3f472512cfe9",
   "root": "reason-fontkit@link-dev:./package.json",
   "node": {
     "rejest@1.3.0@d41d8cd9": {
@@ -16,7 +16,7 @@
       "dependencies": [
         "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "@opam/lwt_ppx@opam:1.2.3@22f5b56c", "@opam/lwt@opam:4.3.0@3f2cb6e0",
-        "@opam/lambda-term@opam:2.0.2@ecff8c4f",
+        "@opam/lambda-term@opam:2.0.2@119fb081",
         "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -39,32 +39,9 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@reason-native/pastel@0.2.1@d41d8cd9",
         "@reason-native/console@0.1.0@d41d8cd9",
-        "@opam/re@opam:1.9.0@fc2ceb05", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/atdgen@opam:2.0.0@5d912e07",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
-    "reason-glfw@3.2.1029@d41d8cd9": {
-      "id": "reason-glfw@3.2.1029@d41d8cd9",
-      "name": "reason-glfw",
-      "version": "3.2.1029",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/reason-glfw/-/reason-glfw-3.2.1029.tgz#sha1:5519aad174fcce32a9c3608c013a1ebbf27f38c9"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
-        "ocaml@4.8.1000@d41d8cd9", "esy-glfw@3.2.1010@d41d8cd9",
-        "esy-cmake@0.3.5@d41d8cd9", "@opam/lwt_ppx@opam:1.2.3@22f5b56c",
-        "@opam/lwt@opam:4.3.0@3f2cb6e0",
-        "@opam/js_of_ocaml-lwt@opam:3.4.0@ce99e929",
-        "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
-        "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
-        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/reason@3.5.0@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -98,8 +75,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "reason-glfw@3.2.1029@d41d8cd9",
-        "reason-gl-matrix@0.9.9305@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "reason-gl-matrix@0.9.9305@d41d8cd9",
         "esy-harfbuzz@1.9.1005@d41d8cd9", "esy-freetype2@2.9.1006@d41d8cd9",
         "esy-cmake@0.3.5@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
@@ -128,20 +104,6 @@
         "type": "install",
         "source": [
           "archive:https://registry.npmjs.org/esy-harfbuzz/-/esy-harfbuzz-1.9.1005.tgz#sha1:04651c73d33ce8004e61fde35a7549a7b9e908b6"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
-      "devDependencies": []
-    },
-    "esy-glfw@3.2.1010@d41d8cd9": {
-      "id": "esy-glfw@3.2.1010@d41d8cd9",
-      "name": "esy-glfw",
-      "version": "3.2.1010",
-      "source": {
-        "type": "install",
-        "source": [
-          "archive:https://registry.npmjs.org/esy-glfw/-/esy-glfw-3.2.1010.tgz#sha1:1e85f36e326eefaeb46ecf093f14da70b5975803"
         ]
       },
       "overrides": [],
@@ -210,8 +172,8 @@
       ],
       "devDependencies": []
     },
-    "@opam/zed@opam:2.0.3@7016ad7c": {
-      "id": "@opam/zed@opam:2.0.3@7016ad7c",
+    "@opam/zed@opam:2.0.3@62853a38": {
+      "id": "@opam/zed@opam:2.0.3@62853a38",
       "name": "@opam/zed",
       "version": "opam:2.0.3",
       "source": {
@@ -231,7 +193,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
-        "@opam/camomile@opam:1.0.1@ab4729e2",
+        "@opam/camomile@opam:1.0.1@a244d067",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -239,7 +201,7 @@
         "ocaml@4.8.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/dune@opam:1.11.3@9894df55",
         "@opam/charInfo_width@opam:1.1.0@a2633e77",
-        "@opam/camomile@opam:1.0.1@ab4729e2",
+        "@opam/camomile@opam:1.0.1@a244d067",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
@@ -289,7 +251,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
@@ -312,12 +274,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@c65fe06a",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
       ]
     },
     "@opam/seq@opam:base@d8d7de1d": {
@@ -339,8 +301,8 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/result@opam:1.4@6fb665c3": {
-      "id": "@opam/result@opam:1.4@6fb665c3",
+    "@opam/result@opam:1.4@dc720aef": {
+      "id": "@opam/result@opam:1.4@dc720aef",
       "name": "@opam/result",
       "version": "opam:1.4",
       "source": {
@@ -383,14 +345,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
-        "@opam/ocamlfind@opam:1.8.1@c65fe06a",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/re@opam:1.9.0@fc2ceb05": {
-      "id": "@opam/re@opam:1.9.0@fc2ceb05",
+    "@opam/re@opam:1.9.0@d4d5e13d": {
+      "id": "@opam/re@opam:1.9.0@d4d5e13d",
       "name": "@opam/re",
       "version": "opam:1.9.0",
       "source": {
@@ -434,17 +396,17 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/ppx_derivers@opam:1.2.1@aee9c3db": {
-      "id": "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+    "@opam/ppx_derivers@opam:1.2.1@ecf0aa45": {
+      "id": "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
       "name": "@opam/ppx_derivers",
       "version": "opam:1.2.1",
       "source": {
@@ -491,20 +453,20 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@c65fe06a",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@c65fe06a",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
-    "@opam/ocamlfind@opam:1.8.1@c65fe06a": {
-      "id": "@opam/ocamlfind@opam:1.8.1@c65fe06a",
+    "@opam/ocamlfind@opam:1.8.1@ff07b0f9": {
+      "id": "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
       "name": "@opam/ocamlfind",
       "version": "opam:1.8.1",
       "source": {
@@ -527,13 +489,13 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/conf-m4@opam:1@da6f4f44",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/conf-m4@opam:1@3b2b148a",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/ocamlbuild@opam:0.14.0@427a2331": {
-      "id": "@opam/ocamlbuild@opam:0.14.0@427a2331",
+    "@opam/ocamlbuild@opam:0.14.0@6ac75d03": {
+      "id": "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
       "name": "@opam/ocamlbuild",
       "version": "opam:0.14.0",
       "source": {
@@ -559,8 +521,8 @@
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334": {
-      "id": "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+    "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d": {
+      "id": "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
       "name": "@opam/ocaml-migrate-parsetree",
       "version": "opam:1.4.0",
       "source": {
@@ -577,18 +539,18 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/mmap@opam:1.1.0@7bef1e51": {
-      "id": "@opam/mmap@opam:1.1.0@7bef1e51",
+    "@opam/mmap@opam:1.1.0@b85334ff": {
+      "id": "@opam/mmap@opam:1.1.0@b85334ff",
       "name": "@opam/mmap",
       "version": "opam:1.1.0",
       "source": {
@@ -655,8 +617,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@c65fe06a",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
@@ -708,19 +670,19 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/lwt@opam:4.3.0@3f2cb6e0", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/lwt_log@opam:1.1.1@91643f38": {
-      "id": "@opam/lwt_log@opam:1.1.1@91643f38",
+    "@opam/lwt_log@opam:1.1.1@2d7a797f": {
+      "id": "@opam/lwt_log@opam:1.1.1@2d7a797f",
       "name": "@opam/lwt_log",
       "version": "opam:1.1.1",
       "source": {
@@ -763,9 +725,9 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/result@opam:1.4@6fb665c3",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@7bef1e51", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
@@ -773,13 +735,13 @@
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/result@opam:1.4@6fb665c3",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@7bef1e51", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/mmap@opam:1.1.0@b85334ff", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/lambda-term@opam:2.0.2@ecff8c4f": {
-      "id": "@opam/lambda-term@opam:2.0.2@ecff8c4f",
+    "@opam/lambda-term@opam:2.0.2@119fb081": {
+      "id": "@opam/lambda-term@opam:2.0.2@119fb081",
       "name": "@opam/lambda-term",
       "version": "opam:2.0.2",
       "source": {
@@ -796,21 +758,21 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@7016ad7c",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@91643f38", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
         "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/camomile@opam:1.0.1@ab4729e2",
+        "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@7016ad7c",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/zed@opam:2.0.3@62853a38",
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/lwt_react@opam:1.1.3@72987fcf",
-        "@opam/lwt_log@opam:1.1.1@91643f38", "@opam/lwt@opam:4.3.0@3f2cb6e0",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:4.3.0@3f2cb6e0",
         "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/camomile@opam:1.0.1@ab4729e2"
+        "@opam/camomile@opam:1.0.1@a244d067"
       ]
     },
     "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e": {
@@ -833,14 +795,14 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
@@ -863,7 +825,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt_log@opam:1.1.1@91643f38",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/lwt_log@opam:1.1.1@2d7a797f",
         "@opam/lwt@opam:4.3.0@3f2cb6e0",
         "@opam/js_of_ocaml-ppx@opam:3.4.0@9743829e",
         "@opam/js_of_ocaml@opam:3.4.0@d8a98a2c",
@@ -895,14 +857,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/ocamlfind@opam:1.8.1@c65fe06a",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/ocamlfind@opam:1.8.1@c65fe06a",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/cmdliner@opam:1.0.4@93208aac"
       ]
@@ -927,14 +889,14 @@
       "dependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/ppx_tools_versioned@opam:5.2.3@4994ec80",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/js_of_ocaml-compiler@opam:3.4.0@d2f7c406",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
@@ -1045,8 +1007,8 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-m4@opam:1@da6f4f44": {
-      "id": "@opam/conf-m4@opam:1@da6f4f44",
+    "@opam/conf-m4@opam:1@3b2b148a": {
+      "id": "@opam/conf-m4@opam:1@3b2b148a",
       "name": "@opam/conf-m4",
       "version": "opam:1",
       "source": {
@@ -1102,15 +1064,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/camomile@opam:1.0.1@ab4729e2",
+        "@opam/camomile@opam:1.0.1@a244d067",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/camomile@opam:1.0.1@ab4729e2"
+        "@opam/camomile@opam:1.0.1@a244d067"
       ]
     },
     "@opam/chalk@opam:1.0@6f5da5ff": {
@@ -1131,15 +1093,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@c65fe06a",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@c65fe06a"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9"
       ]
     },
-    "@opam/camomile@opam:1.0.1@ab4729e2": {
-      "id": "@opam/camomile@opam:1.0.1@ab4729e2",
+    "@opam/camomile@opam:1.0.1@a244d067": {
+      "id": "@opam/camomile@opam:1.0.1@a244d067",
       "name": "@opam/camomile",
       "version": "opam:1.0.1",
       "source": {
@@ -1236,11 +1198,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@c65fe06a",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@c65fe06a"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9"
       ]
     },
     "@opam/atdgen-runtime@opam:2.0.0@8a75c3bb": {
@@ -1355,9 +1317,9 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ocamlfind@opam:1.8.1@c65fe06a",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
         "@opam/menhir@opam:20190626@bbeb8953",
         "@opam/dune@opam:1.11.3@9894df55"

--- a/esy.lock/opam/camomile.1.0.1/opam
+++ b/esy.lock/opam/camomile.1.0.1/opam
@@ -3,7 +3,7 @@ maintainer: "yoriyuki.y@gmail.com"
 authors: ["Yoriyuki Yamagata"]
 homepage: "https://github.com/yoriyuki/Camomile/wiki"
 bug-reports: "https://github.com/yoriyuki/Camomile/issues"
-license: "LGPL-2+ with OCaml linking exception"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 build: [
   ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]

--- a/esy.lock/opam/conf-m4.1/opam
+++ b/esy.lock/opam/conf-m4.1/opam
@@ -3,7 +3,7 @@ maintainer: "tim@gfxmonk.net"
 homepage: "http://www.gnu.org/software/m4/m4.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "GNU Project"
-license: "GPL-3"
+license: "GPL-3.0-only"
 build: [["sh" "-exc" "echo | m4"]]
 depexts: [
   ["m4"] {os-family = "debian"}

--- a/esy.lock/opam/lambda-term.2.0.2/opam
+++ b/esy.lock/opam/lambda-term.2.0.2/opam
@@ -4,7 +4,7 @@ authors: ["Jérémie Dimino"]
 homepage: "https://github.com/ocaml-community/lambda-term"
 bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
 dev-repo: "git://github.com/ocaml-community/lambda-term.git"
-license: "BSD3"
+license: "BSD-3-Clause"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/esy.lock/opam/lwt_log.1.1.1/opam
+++ b/esy.lock/opam/lwt_log.1.1.1/opam
@@ -3,7 +3,7 @@ opam-version: "2.0"
 synopsis: "Lwt logging library (deprecated)"
 
 version: "1.1.1"
-license: "LGPL"
+license: "LGPL-2.0-or-later"
 homepage: "https://github.com/ocsigen/lwt_log"
 doc: "https://github.com/ocsigen/lwt_log/blob/master/src/core/lwt_log_core.mli"
 bug-reports: "https://github.com/ocsigen/lwt_log/issues"

--- a/esy.lock/opam/mmap.1.1.0/opam
+++ b/esy.lock/opam/mmap.1.1.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/mirage/mmap"
 bug-reports: "https://github.com/mirage/mmap/issues"
 doc: "https://mirage.github.io/mmap/"
 dev-repo: "git+https://github.com/mirage/mmap.git"
-license: "LGPL 2.1 with linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/esy.lock/opam/ocaml-migrate-parsetree.1.4.0/opam
+++ b/esy.lock/opam/ocaml-migrate-parsetree.1.4.0/opam
@@ -4,7 +4,7 @@ authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
   "Jérémie Dimino <jeremie@dimino.org>"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"

--- a/esy.lock/opam/ocamlbuild.0.14.0/opam
+++ b/esy.lock/opam/ocamlbuild.0.14.0/opam
@@ -3,7 +3,7 @@ maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
 authors: ["Nicolas Pouillard" "Berke Durak"]
 homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
 build: [

--- a/esy.lock/opam/ocamlfind.1.8.1/opam
+++ b/esy.lock/opam/ocamlfind.1.8.1/opam
@@ -47,3 +47,4 @@ url {
   checksum: "md5=18ca650982c15536616dea0e422cbd8c"
   mirrors: "http://download2.camlcity.org/download/findlib-1.8.1.tar.gz"
 }
+depopts: ["graphics"]

--- a/esy.lock/opam/ppx_derivers.1.2.1/opam
+++ b/esy.lock/opam/ppx_derivers.1.2.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "jeremie@dimino.org"
 authors: ["Jérémie Dimino"]
-license: "BSD3"
+license: "BSD-3-Clause"
 homepage: "https://github.com/ocaml-ppx/ppx_derivers"
 bug-reports: "https://github.com/ocaml-ppx/ppx_derivers/issues"
 dev-repo: "git://github.com/ocaml-ppx/ppx_derivers.git"

--- a/esy.lock/opam/re.1.9.0/opam
+++ b/esy.lock/opam/re.1.9.0/opam
@@ -8,7 +8,7 @@ authors: [
   "Rudi Grinberg"
   "Gabriel Radanne"
 ]
-license: "LGPL-2.0 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/ocaml-re"
 bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml-re.git"

--- a/esy.lock/opam/result.1.4/opam
+++ b/esy.lock/opam/result.1.4/opam
@@ -4,7 +4,7 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"
-license: "BSD3"
+license: "BSD-3-Clause"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"

--- a/esy.lock/opam/zed.2.0.3/opam
+++ b/esy.lock/opam/zed.2.0.3/opam
@@ -4,7 +4,7 @@ authors: ["Jérémie Dimino"]
 homepage: "https://github.com/ocaml-community/zed"
 bug-reports: "https://github.com/ocaml-community/zed/issues"
 dev-repo: "git://github.com/ocaml-community/zed.git"
-license: "BSD3"
+license: "BSD-3-Clause"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.1.0"}

--- a/fontkit-example.opam
+++ b/fontkit-example.opam
@@ -1,0 +1,7 @@
+opam-version: "1.2"
+version: "dev"
+maintainer: "bryphe@outlook.com"
+author: ["Bryan Phelps"]
+build: [
+
+]

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
       [
         "dune",
         "build",
-        "--root",
-        "."
+        "-p",
+        "fontkit"
       ]
     ],
     "install": [
@@ -20,7 +20,6 @@
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "^3.3.7",
     "refmterr": "^3.1.0",
-    "reason-glfw": "^3.2.1029",
     "reason-gl-matrix": "^0.9.9305",
     "esy-cmake": "^0.3.4",
     "esy-freetype2": "^2.9.1001",

--- a/src/dune
+++ b/src/dune
@@ -6,7 +6,7 @@
     (library_flags (:include flags.sexp))
     (c_flags (:include c_flags.sexp))
     (cxx_flags (:include cxx_flags.sexp))
-    (libraries reglfw))
+    (libraries lwt))
 
 (rule
     (targets c_flags.sexp cxx_flags.sexp flags.sexp)


### PR DESCRIPTION
In the switch of Revery -> SDL2, I found that `reason-fontkit` was still pulling in GLFW for the sample app.

This change moves the sample app to its own package, and moves the dependency to GLFW there. A next step would be to update this sample to use SDL2, instead.