### PR TITLE
Only use /opt/local/lib if it exists.

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -23,16 +23,18 @@ let c_flags = ["-fPIC"; "-I";  (Sys.getenv "FREETYPE2_INCLUDE_PATH"); "-I"; (Sys
 let ccopt s = ["-ccopt"; s]
 let cclib s = ["-cclib"; s]
 
-let extraFlags = 
+let extraFlags =
     match get_os with
     | Windows -> []
     | _ -> []
     @ ccopt ("-L/usr/lib")
     @ ccopt ("-L/usr/local/lib")
-    @ ccopt ("-L/opt/local/lib")
     @ cclib ("-lbz2")
     @ cclib ("-lpng")
     @ cclib ("-lz")
+    @ match Sys.file_exists "/opt/local/lib" with
+      | true -> ccopt ("-L/opt/local/lib")
+      | false -> []
 
 let lib_path_flags =
     match get_os with


### PR DESCRIPTION
Just a test on removing this when it doesn't exist, since it gives a warning on everything that consumes it (revery, Oni2 etc).

My mac doesn't even have an /opt/local, and it looks to only be there on mac if `macports` is used, whereas I use `brew`. The CI up to this point has had the same warning, so should be able to tell from there.