### PR TITLE
Bugfix: Don't pick up global paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   "dependencies": {
     "@opam/dune": ">=1.6.0",
     "@opam/lwt": "*",
-    "@esy-ocaml/reason": "^3.3.7",
     "reason-gl-matrix": "^0.9.9305",
-    "esy-cmake": "^0.3.4",
     "esy-freetype2": "^2.9.1001",
     "esy-harfbuzz": "^1.9.1005"
   },
@@ -30,6 +28,8 @@
     "@opam/camomile": "1.0.1"
   },
   "devDependencies": {
+    "esy-cmake": "^0.3.4",
+    "@esy-ocaml/reason": "^3.3.7",
     "ocaml": ">=4.4.0"
   }
 }

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -27,9 +27,7 @@ let extraFlags =
     match get_os with
     | Windows -> []
     | _ -> []
-    @ ccopt ("-L/usr/lib")
     @ ccopt ("-L/usr/local/lib")
-    @ ccopt ("-L/opt/local/lib")
     @ cclib ("-lbz2")
     @ cclib ("-lpng")
     @ cclib ("-lz")


### PR DESCRIPTION
Found while testing out @manuhornung 's latest work on https://github.com/revery-ui/revery/pull/567

Remove global paths that break us out of the sandbox.