### PR TITLE
Bugfix: Bring back /usr/lib on Linux

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -23,10 +23,7 @@ let c_flags = ["-fPIC"; "-I";  (Sys.getenv "FREETYPE2_INCLUDE_PATH"); "-I"; (Sys
 let ccopt s = ["-ccopt"; s]
 let cclib s = ["-cclib"; s]
 
-let extraFlags =
-    match get_os with
-    | Windows -> []
-    | _ -> []
+let posixFlags = []
     @ ccopt ("-L/usr/local/lib")
     @ cclib ("-lbz2")
     @ cclib ("-lpng")
@@ -34,6 +31,13 @@ let extraFlags =
     @ match Sys.file_exists "/opt/local/lib" with
       | true -> ccopt ("-L/opt/local/lib")
       | false -> []
+
+let extraFlags =
+    match get_os with
+    | Windows -> []
+    | Mac -> posixFlags
+    | Linux -> ccopt("-L/usr/lib")
+        @ posixFlags
 
 let lib_path_flags =
     match get_os with

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -37,7 +37,7 @@ let extraFlags =
     | Windows -> []
     | Mac -> posixFlags
     | Linux -> ccopt("-L/usr/lib")
-        @ posixFlags
+    @ posixFlags
 
 let lib_path_flags =
     match get_os with


### PR DESCRIPTION
Related to https://github.com/revery-ui/revery/issues/666 - thanks @Et7f3 for all of your help investigating! 💯 

Unfortunately, bumping up the harfbuzz version is problematic for packaging - see https://github.com/onivim/oni2/issues/514 for details

I took out the `/usr/lib` dependency primarily for OSX - caused problems when trying to build Skia due to collisions with homebrew. We don't pull as many libs from `/usr/lib` on OSX, but on Linux, we rely on many more dependencies - like GTK 3 which brings in `pango`, etc - and if these have a different / newer version of harfbuzz, it'll cause problems. 

So I think the safest fix is to bring `/usr/lib` back for Linux. Unfortunately that means we still have the requirement that `harfbuzz` has to be installed. But it will help us avoid the packaging issues.